### PR TITLE
Improve error messages of wrong dimensions

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -51,9 +51,9 @@ Tensor& s_addmm_out_sparse_dense_cuda(Tensor& r_, const Tensor& t, const SparseT
   AT_CHECK(_check_device({sparse_, r_, t, dense}));
 
   // TODO: This error message seems awfully opaque
-  AT_CHECK(sparse_._sparseDims() == 2, "addmm: matrices expected, got ", sparse_._sparseDims(), "D tensor");
+  AT_CHECK(sparse_._sparseDims() == 2, "addmm: 2D tensor expected, got ", sparse_._sparseDims(), "D tensor");
   AT_CHECK(sparse_._denseDims() == 0, "addmm: scalar values expected, got ", sparse_._denseDims(), "D values");
-  AT_CHECK(dense.dim() == 2, "addmm: matrices expected, got ", dense.dim(), "D tensor");
+  AT_CHECK(dense.dim() == 2, "addmm: 2D tensor expected, got ", dense.dim(), "D tensor");
 
   // mxk * kxn = mxn
   int64_t m = sparse_.size(0);
@@ -183,11 +183,11 @@ SparseTensor& hspmm_out_sparse_cuda(SparseTensor& r_, const SparseTensor& sparse
   AT_CHECK(_check_device({r_, sparse_, dense}));
 
   AT_CHECK(sparse_._sparseDims() == 2,
-      "hspmm: Argument #2: matrices expected, got ", sparse_._sparseDims(), "D tensor");
+      "hspmm: Argument #2: 2D tensor expected, got ", sparse_._sparseDims(), "D tensor");
   AT_CHECK(sparse_._denseDims() == 0,
       "hspmm: Argument #2: scalar values expected, got ", sparse_._denseDims(), "D values");
   AT_CHECK(dense.dim() == 2,
-      "hspmm: Argument #3: matrices expected, got ", dense.dim(), "D tensor");
+      "hspmm: Argument #3: 2D tensor expected, got ", dense.dim(), "D tensor");
 
   int64_t m = sparse_.size(0);
   int64_t k = sparse_.size(1);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -1949,7 +1949,7 @@ void THTensor_(addcdiv)(THTensor *r_, THTensor *t, real value, THTensor *src1, T
 void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *mat, THTensor *vec)
 {
   if( (mat->dim() != 2) || (vec->dim() != 1) )
-    THError("matrix and vector expected, got %dD, %dD",
+    THError("2D tensor and 1D tensor expected, got %dD, %dD tensors",
       mat->dim(), vec->dim());
 
   if( mat->size(1) != vec->size(0) ) {
@@ -1959,7 +1959,7 @@ void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   }
 
   if(t->dim() != 1)
-    THError("vector expected, got t: %dD", t->dim());
+    THError("1D tensor expected, got t: %dD tensor", t->dim());
 
   if(t->size(0) != mat->size(0)) {
     THDescBuff bt = THTensor_(sizeDesc)(t);
@@ -2055,7 +2055,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   int free_m2 = 0;
 
   if( (m1->dim() != 2) || (m2->dim() != 2))
-    THError("matrices expected, got %dD, %dD tensors", m1->dim(), m2->dim());
+    THError("2D tensors expected, got %dD, %dD tensors", m1->dim(), m2->dim());
 
   if(m1->size(1) != m2->size(0)) {
     THDescBuff bm1 = THTensor_(sizeDesc)(m1);
@@ -2064,7 +2064,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   }
 
   if( t->dim() != 2 )
-    THError("matrix expected, got %dD tensor for t", t->dim());
+    THError("1D tensor expected, got %dD tensor for t", t->dim());
 
   if( (t->size(0) != m1->size(0)) || (t->size(1) != m2->size(1)) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
@@ -2196,7 +2196,7 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
         vec1->dim(), vec2->dim());
 
   if(t->dim() != 2)
-    THError("expected matrix, got %dD tensor for t", t->dim());
+    THError("expected 2D tensor, got %dD tensor for t", t->dim());
 
   if( (t->size(0) != vec1->size(0)) || (t->size(1) != vec2->size(0)) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
@@ -3528,7 +3528,7 @@ void THTensor_(tril)(THTensor *r_, THTensor *t, int64_t k)
   real *t_data, *r__data;
   int64_t r, c;
 
-  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a matrix");
+  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a 2D tensor");
 
   THTensor_(resizeAs)(r_, t);
 
@@ -3559,7 +3559,7 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
   real *t_data, *r__data;
   int64_t r, c;
 
-  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a matrix");
+  THArgCheck(THTensor_(_nDimension)(t) == 2, 1, "expected a 2D tensor");
 
   THTensor_(resizeAs)(r_, t);
 

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -51,7 +51,7 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, mat, vec));
   if( (mat->dim() != 2) || (vec->dim() != 1) )
     THError("2D tensor and 1D tensor expected, got %dD, %dD tensors",
-       mat->dim(), vec->dim())
+       mat->dim(), vec->dim());
 
   if( mat->size(1) != vec->size(0) )
     THError("size mismatch");
@@ -153,7 +153,7 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, vec1, vec2));
   if ( (vec1->dim() != 1) || (vec2->dim() != 1) ) {
     THError("1D tensor and 1D tensor expected, got %dD, %dD tensors",
-       vec1->dim(), vec2->dim())
+       vec1->dim(), vec2->dim());
   }
 
   if (t->dim() != 2) {

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -50,7 +50,7 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, mat, vec));
   if( (mat->dim() != 2) || (vec->dim() != 1) )
-    THError("matrix and vector expected");
+    THError("2D tensor and 1D tensor expected");
 
   if( mat->size(1) != vec->size(0) )
     THError("size mismatch");
@@ -248,10 +248,10 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCTensor *r__, *m1_, *m2_;
 
   if( (m1->dim() != 2) || (m2->dim() != 2) )
-    THError("matrices expected, got %dD, %dD tensors", m1->dim(), m2->dim());
+    THError("2D tensors expected, got %dD, %dD tensors", m1->dim(), m2->dim());
 
   if(t->dim() != 2)
-    THError("matrix expected, got %dD tensor for t", t->dim());
+    THError("2D tensor expected, got %dD tensor for t", t->dim());
 
   if(m1->size(1) != m2->size(0)) {
     THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -50,7 +50,8 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, mat, vec));
   if( (mat->dim() != 2) || (vec->dim() != 1) )
-    THError("2D tensor and 1D tensor expected");
+    THError("2D tensor and 1D tensor expected, got %dD, %dD tensors",
+       mat->dim(), vec->dim())
 
   if( mat->size(1) != vec->size(0) )
     THError("size mismatch");
@@ -151,7 +152,8 @@ THCTensor_(addr)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real a
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 4, r_, t, vec1, vec2));
   if ( (vec1->dim() != 1) || (vec2->dim() != 1) ) {
-    THError("vector and vector expected");
+    THError("1D tensor and 1D tensor expected, got %dD, %dD tensors",
+       vec1->dim(), vec2->dim())
   }
 
   if (t->dim() != 2) {

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
@@ -1038,7 +1038,7 @@ void THDTensor_(addcdiv)(THDTensor *self, THDTensor *src1, real value, THDTensor
 
 void THDTensor_(addmv)(THDTensor *self, real beta, THDTensor *src, real alpha, THDTensor *mat,  THDTensor *vec) {
   if ((mat->nDimension != 2) || (vec->nDimension != 1))
-    THError("matrix and vector expected, got %dD, %dD", mat->nDimension, vec->nDimension);
+    THError("2D tensor and 1D tensor expected, got %dD tensor, %dD tensor", mat->nDimension, vec->nDimension);
 
   if (mat->size[1] != vec->size[0]) {
     THDDescBuff bm = THDTensor_(sizeDesc)(mat);
@@ -1047,7 +1047,7 @@ void THDTensor_(addmv)(THDTensor *self, real beta, THDTensor *src, real alpha, T
   }
 
   if (src->nDimension != 1)
-    THError("vector expected, got src: %dD", src->nDimension);
+    THError("1D tensor expected, got src: %dD tensor", src->nDimension);
 
   if (src->size[0] != mat->size[0]) {
     THDDescBuff bt = THDTensor_(sizeDesc)(src);
@@ -1067,7 +1067,7 @@ void THDTensor_(addmv)(THDTensor *self, real beta, THDTensor *src, real alpha, T
 
 void THDTensor_(addmm)(THDTensor *self, real beta, THDTensor *src, real alpha, THDTensor *mat1, THDTensor *mat2) {
   if ((mat1->nDimension != 2) || (mat2->nDimension != 2))
-    THError("matrices expected, got %dD, %dD tensors", mat1->nDimension, mat2->nDimension);
+    THError("2D tensors expected, got %dD, %dD tensors", mat1->nDimension, mat2->nDimension);
 
   if (mat1->size[1] != mat2->size[0]) {
     THDDescBuff bm1 = THDTensor_(sizeDesc)(mat1);
@@ -1076,7 +1076,7 @@ void THDTensor_(addmm)(THDTensor *self, real beta, THDTensor *src, real alpha, T
   }
 
   if (src->nDimension != 2)
-    THError("matrix expected, got %dD tensor for t", src->nDimension);
+    THError("2D tensors expected, got %dD tensor for t", src->nDimension);
 
   if ((src->size[0] != mat1->size[0]) || (src->size[1] != mat2->size[1])) {
     THDDescBuff bt  = THDTensor_(sizeDesc)(src);
@@ -1246,7 +1246,7 @@ void THDTensor_(sign)(THDTensor *self, THDTensor *src) {
 }
 
 accreal THDTensor_(trace)(THDTensor *self) {
-  THArgCheck(self->nDimension == 2, 1, "expected a matrix");
+  THArgCheck(self->nDimension == 2, 1, "expected a 2D tensor");
 
   masterCommandChannel->sendMessage(
     packMessage(Functions::tensorTrace, self),

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
@@ -1038,7 +1038,7 @@ void THDTensor_(addcdiv)(THDTensor *self, THDTensor *src1, real value, THDTensor
 
 void THDTensor_(addmv)(THDTensor *self, real beta, THDTensor *src, real alpha, THDTensor *mat,  THDTensor *vec) {
   if ((mat->nDimension != 2) || (vec->nDimension != 1))
-    THError("2D tensor and 1D tensor expected, got %dD tensor, %dD tensor", mat->nDimension, vec->nDimension);
+    THError("2D tensor and 1D tensor expected, got %dD, %dD tensors", mat->nDimension, vec->nDimension);
 
   if (mat->size[1] != vec->size[0]) {
     THDDescBuff bm = THDTensor_(sizeDesc)(mat);


### PR DESCRIPTION
Updated the error message terms _matrices_ and _vectors_ to _2D tensors_ and _1D tensors_ respectively. 
#39 